### PR TITLE
feat: rework periodic cleanup scheduling

### DIFF
--- a/periodic_cleanup.py
+++ b/periodic_cleanup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import asyncio
+import datetime
 import logging
 
 import asyncpg
@@ -10,6 +11,13 @@ from db import DatabaseLifecycleHandler
 
 logger = logging.getLogger(__name__)
 
+signal = asyncio.Event()
+MAX_WAIT = 300
+
+
+def reschedule():
+    signal.set()
+
 
 async def periodic_cleanup(config: DefaultConfig, database: DatabaseLifecycleHandler):
     return await _log_exception(_cleanup_task(config, database))
@@ -19,11 +27,15 @@ async def _cleanup_task(config: DefaultConfig, database: DatabaseLifecycleHandle
     client = httpx.AsyncClient()
     while True:
         # Cleanup message function goes here :)
+        wait_sec = MAX_WAIT
         try:
             connection: asyncpg.Connection
             async with await database.acquire() as connection:
                 stmt = await connection.prepare(
-                    "SELECT msg_to_delete_id, message_id FROM msg_to_delete WHERE expire_at < NOW()"
+                    """SELECT msg_to_delete_id, message_id
+                        FROM msg_to_delete
+                        WHERE expire_at < NOW()
+                        FOR UPDATE"""
                 )
                 async with connection.transaction():
                     async for record in stmt.cursor():
@@ -44,9 +56,18 @@ async def _cleanup_task(config: DefaultConfig, database: DatabaseLifecycleHandle
                             logger.info("deleted message %s", record["msg_to_delete_id"])
                         except Exception as e:
                             logger.exception(f"Error processing record {record['msg_to_delete_id']}: {e}")
+                value = await connection.fetchval("SELECT min(expire_at) FROM msg_to_delete")
+                if value is not None:
+                    wait_sec = min(MAX_WAIT, (value - datetime.datetime.now(tz=datetime.UTC)).total_seconds())
         except Exception as e:
             logger.exception(e)
-        await asyncio.sleep(2)
+        try:
+            logger.debug(f"wait for signal or {wait_sec}s")
+            await asyncio.wait_for(signal.wait(), wait_sec)
+            signal.clear()
+            logger.debug("signal received")
+        except TimeoutError:
+            logger.debug("wait_for timeout")
 
 
 async def _log_exception(awaitable):

--- a/webhook/merge_request.py
+++ b/webhook/merge_request.py
@@ -7,6 +7,7 @@ import asyncpg
 import httpx
 from pydantic import BaseModel
 
+import periodic_cleanup
 from cards.render import render
 from config import config
 from db import database
@@ -257,6 +258,7 @@ async def merge_request(
                     "DELETE FROM merge_request_ref WHERE merge_request_ref_id = $1",
                     mri.merge_request_ref_id,
                 )
+            periodic_cleanup.reschedule()
 
     return {
         "merge_request_infos": mri,


### PR DESCRIPTION
and use rows as "lock" for multi instances (kube deploy for example)