### PR TITLE
feat: rework draft handling and draft to ready transition

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,6 +54,7 @@ repos:
         additional_dependencies:
           - pydantic
           - types-PyYAML
+          - types-python-dateutil
         args:
           - --check-untyped-defs
           - --disallow-any-generics

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 python-dotenv
+python-dateutil
 pydantic
 asyncpg
 httpx


### PR DESCRIPTION
Draft are no longer deleted, instead they are collapsed.

When a MR is set to ready, old draft messages will be deleted and new messages will be posted for the card to be moved to the most recent position