### PR TITLE
feat: remove approvals on new commits/push…

### DIFF
--- a/app.py
+++ b/app.py
@@ -93,6 +93,7 @@ async def handle_webhook(
     x_conversation_token: Annotated[str, Header()],
     x_gitlab_token: Annotated[str, Header()],
     filter_on_participant_ids: str | None = None,
+    new_commits_revoke_approvals: bool = True,
 ):
     validate_gitlab_token(x_gitlab_token)
     conversation_tokens = list(
@@ -114,7 +115,12 @@ async def handle_webhook(
                         detail="filter_on_participant_ids must be a list of comma separated integers",
                     )
 
-            await webhook.merge_request(payload, conversation_tokens, participant_ids_filter)
+            await webhook.merge_request(
+                payload,
+                conversation_tokens,
+                participant_ids_filter,
+                new_commits_revoke_approvals,
+            )
         if isinstance(payload, PipelinePayload):
             await webhook.pipeline(payload, conversation_tokens)
         if isinstance(payload, EmojiPayload):

--- a/gitlab_model.py
+++ b/gitlab_model.py
@@ -37,6 +37,7 @@ class GLMRAttributes(BaseModel, extra="allow"):
     url: str
     action: str
     updated_at: str | None
+    oldrev: str | None = None
 
     # https://docs.gitlab.com/ee/api/merge_requests.html#merge-status
     detailed_merge_status: str  # mergeable, not_approved


### PR DESCRIPTION
 (can be disabled by setting `new_commits_revoke_approvals` to false in the query string)

Be careful if several instances of web hook are registered of a single MR, all must bear the flag.

value can be:
* for true: t, true, y, 1
* for false: f, false, n, 0