### PR TITLE
feat: out-of-order protection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ misc
 .coverage
 .pytest_cache
 *.pyc
+gitlab_mr_api.egg-info

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,12 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
-  - repo: https://github.com/psf/black
-    rev: 24.10.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.8.3
     hooks:
-      - id: black
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
+      - id: ruff-format
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
@@ -20,19 +22,6 @@ repos:
       - id: detect-private-key
       - id: debug-statements
         language_version: python3
-
-  - repo: https://github.com/PyCQA/flake8
-    rev: 7.1.1
-    hooks:
-      - id: flake8
-        args: [--max-line-length, "110"]
-        language_version: python3
-
-  - repo: https://github.com/asottile/reorder_python_imports
-    rev: v3.13.0
-    hooks:
-      - id: reorder-python-imports
-        args: ["--application-directories=.:src", "--py36-plus"]
 
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.17.0

--- a/cards/render.py
+++ b/cards/render.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
 import datetime
 import json
+
 from enum import Enum
 from typing import Any
 
 import yaml
+
 from jinja2 import Environment
 from jinja2 import FileSystemLoader
 from jinja2 import Template

--- a/config.py
+++ b/config.py
@@ -3,6 +3,7 @@ import os
 
 import dotenv
 
+
 dotenv.load_dotenv()
 
 __all__ = ["DefaultConfig", "config"]
@@ -20,7 +21,7 @@ class DefaultConfig:
     _valid_tokens: list[str]
 
     def __init__(self):
-        self._valid_tokens = list([t.strip() for t in self.VALID_X_GITLAB_TOKEN.lower().split(",")])
+        self._valid_tokens = [t.strip() for t in self.VALID_X_GITLAB_TOKEN.lower().split(",")]
         self.log_queries = False
         if len(self.LOG_QUERIES) and self.LOG_QUERIES[0].lower() in ("y", "t", "1"):
             self.log_queries = True

--- a/db/migrations/20251210000000_add_last_processed_updated_at.sql
+++ b/db/migrations/20251210000000_add_last_processed_updated_at.sql
@@ -1,0 +1,7 @@
+-- migrate:up
+ALTER TABLE gitlab_mr_api.merge_request_message_ref
+ADD COLUMN last_processed_updated_at timestamp with time zone;
+
+-- migrate:down
+ALTER TABLE gitlab_mr_api.merge_request_message_ref
+DROP COLUMN last_processed_updated_at;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -82,7 +82,8 @@ CREATE TABLE gitlab_mr_api.merge_request_message_ref (
     failure jsonb,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     updated_at timestamp with time zone,
-    last_processed_fingerprint character varying(64)
+    last_processed_fingerprint character varying(64),
+    last_processed_updated_at timestamp with time zone
 );
 
 

--- a/gitlab_model.py
+++ b/gitlab_model.py
@@ -37,7 +37,7 @@ class GLMRAttributes(BaseModel, extra="allow"):
     state: str
     url: str
     action: str
-    updated_at: str | None
+    updated_at: str
     oldrev: str | None = None
 
     # https://docs.gitlab.com/ee/api/merge_requests.html#merge-status

--- a/gitlab_model.py
+++ b/gitlab_model.py
@@ -23,6 +23,7 @@ class GLUser(BaseModel, extra="allow"):
 
 
 class GLProject(BaseModel, extra="allow"):
+    id: int
     path_with_namespace: str
     web_url: str
 
@@ -80,6 +81,7 @@ class PipelinePayload(BaseModel, extra="allow"):
     object_kind: Literal["pipeline"]
     object_attributes: GLPipelineAttributes
     builds: list[GLPipelineBuild]
+    project: GLProject
 
 
 class GLEmojiAttributes(BaseModel, extra="allow"):

--- a/periodic_cleanup.py
+++ b/periodic_cleanup.py
@@ -9,6 +9,7 @@ import httpx
 from config import DefaultConfig
 from db import DatabaseLifecycleHandler
 
+
 logger = fastapi_structured_logging.get_logger()
 
 signal = asyncio.Event()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,26 @@ requires-python = ">=3.12"
 license = "MIT"
 dynamic = ["version"]
 
-[tool.black]
+[tool.ruff]
 line-length = 110
+target-version = "py312"
+
+[tool.ruff.lint]
+select = [
+    "E",   # pycodestyle errors
+    "W",   # pycodestyle warnings
+    "F",   # pyflakes
+    "I",   # isort
+    "B",   # flake8-bugbear
+    "C4",  # flake8-comprehensions
+    "UP",  # pyupgrade
+]
+
+[tool.ruff.lint.isort]
+known-first-party = ["webhook", "db", "gitlab_model", "cards", "config"]
+force-single-line = true
+lines-after-imports = 2
+lines-between-types = 1
 
 [tool.mypy]
 check_untyped_defs = true

--- a/run.sh
+++ b/run.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
 
-export OTEL_PYTHON_EXCLUDED_URLS=${OTEL_PYTHON_EXCLUDED_URLS:-healthz}
-
-exec /app/.venv/bin/opentelemetry-instrument \
-    --traces_exporter otlp \
-    --metrics_exporter otlp \
-    --logs_exporter otlp \
-    --service_name notifier-gitlab-mr-api \
-    /app/.venv/bin/uvicorn app:app --host 0.0.0.0 --port 8000
+if [ -n "$OTEL_EXPORTER_OTLP_ENDPOINT" ]; then
+    export OTEL_PYTHON_EXCLUDED_URLS=${OTEL_PYTHON_EXCLUDED_URLS:-healthz}
+    exec /app/.venv/bin/opentelemetry-instrument \
+        --traces_exporter otlp \
+        --metrics_exporter otlp \
+        --logs_exporter otlp \
+        --service_name notifier-gitlab-mr-api \
+        /app/.venv/bin/uvicorn app:app --host 0.0.0.0 --port 8000
+else
+    exec /app/.venv/bin/uvicorn app:app --host 0.0.0.0 --port 8000
+fi

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 import time
 import uuid
+
+from collections.abc import AsyncGenerator
 from typing import Any
-from typing import AsyncGenerator
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 
@@ -22,7 +23,7 @@ class MockRecord(dict[str, Any]):
         try:
             return self[name]
         except KeyError:
-            raise AttributeError(name)
+            raise AttributeError(name) from None
 
 
 class MockConnection:
@@ -210,6 +211,7 @@ def sample_merge_request_payload():
             email="testuser@example.com",
         ),
         project=GLProject(
+            id=1,
             path_with_namespace="test/project",
             web_url="https://gitlab.example.com/test/project",
         ),
@@ -217,12 +219,12 @@ def sample_merge_request_payload():
             id=123,
             iid=1,
             title="Test MR",
-            created_at="2025-01-01T00:00:00Z",
+            created_at="2025-01-01 00:00:00 UTC",
             draft=False,
             state="merged",
             url="https://gitlab.example.com/test/project/-/merge_requests/1",
             action="merge",
-            updated_at="2025-01-01T00:00:00Z",
+            updated_at="2025-01-01 00:00:00 UTC",
             detailed_merge_status="mergeable",
             head_pipeline_id=None,
             work_in_progress=False,

--- a/tests/test_card_render.py
+++ b/tests/test_card_render.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Tests for cards/render.py - YAML template rendering."""
+
 from cards.render import render
 from cards.render import yaml_escape_sq
 from db import GitlabUser
@@ -36,6 +37,7 @@ def make_mri(
             email="test@example.com",
         ),
         project=GLProject(
+            id=1,
             path_with_namespace="test/project",
             web_url="https://gitlab.example.com/test/project",
         ),
@@ -43,12 +45,12 @@ def make_mri(
             id=123,
             iid=1,
             title=title,
-            created_at="2025-01-01T00:00:00Z",
+            created_at="2025-01-01 00:00:00 UTC",
             draft=False,
             state="opened",
             url="https://gitlab.example.com/test/project/-/merge_requests/1",
             action="open",
-            updated_at="2025-01-01T00:00:00Z",
+            updated_at="2025-01-01 00:00:00 UTC",
             detailed_merge_status="mergeable",
             head_pipeline_id=None,
             work_in_progress=False,

--- a/tests/test_database_helpers.py
+++ b/tests/test_database_helpers.py
@@ -7,6 +7,7 @@ Tests DBHelper methods:
 - get_merge_request_ref_infos
 - _generic_norm_upsert
 """
+
 from typing import Any
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
@@ -26,7 +27,7 @@ class MockRecord(dict[str, Any]):
         try:
             return self[name]
         except KeyError:
-            raise AttributeError(name)
+            raise AttributeError(name) from None
 
 
 # Store original Record for restoration
@@ -336,8 +337,9 @@ async def test_generic_norm_upsert_with_insert_only_vals(mock_database):
 @pytest.mark.asyncio
 async def test_generic_norm_upsert_race_condition_handling(mock_database):
     """Test generic upsert handles race condition (UniqueViolationError)."""
-    from db import DBHelper
     import asyncpg.exceptions
+
+    from db import DBHelper
 
     connection = mock_database.connection
 
@@ -379,8 +381,8 @@ async def test_generic_norm_upsert_race_condition_handling(mock_database):
 @pytest.mark.asyncio
 async def test_database_lifecycle_connect_disconnect(mock_database):
     """Test database connection lifecycle."""
-    from db import DatabaseLifecycleHandler
     from config import DefaultConfig
+    from db import DatabaseLifecycleHandler
 
     config = DefaultConfig()
 

--- a/tests/test_e2e_bug_validation.py
+++ b/tests/test_e2e_bug_validation.py
@@ -4,10 +4,13 @@ E2E validation of critical bugs with real database.
 
 These tests demonstrate the bugs exist with real database operations.
 """
+
 import uuid
+
 from unittest.mock import patch
 
 import pytest
+
 
 pytestmark = pytest.mark.e2e
 
@@ -54,8 +57,8 @@ def mr_payload():
             "assignee_id": None,
             "iid": 1,
             "title": "Test MR",
-            "created_at": "2025-01-01T00:00:00Z",
-            "updated_at": "2025-01-01T00:00:00Z",
+            "created_at": "2025-01-01 00:00:00 UTC",
+            "updated_at": "2025-01-01 00:00:00 UTC",
             "state": "opened",
             "merge_status": "can_be_merged",
             "detailed_merge_status": "not_open",
@@ -89,10 +92,11 @@ async def test_e2e_bug_non_transactional_deletion(
     All deletion operations (INSERT into msg_to_delete + DELETE from refs)
     happen within a transaction, ensuring consistency.
     """
-    from db import DBHelper, DatabaseLifecycleHandler
     from config import DefaultConfig
-    from webhook.merge_request import merge_request
+    from db import DatabaseLifecycleHandler
+    from db import DBHelper
     from gitlab_model import MergeRequestPayload
+    from webhook.merge_request import merge_request
 
     config = DefaultConfig()
     config.DATABASE_URL = test_database_url
@@ -110,7 +114,6 @@ async def test_e2e_bug_non_transactional_deletion(
         patch("webhook.merge_request.render") as mock_render,
         patch("webhook.merge_request.periodic_cleanup"),
     ):
-
         mock_render.return_value = {"type": "AdaptiveCard"}
 
         # Create MR with open action

--- a/tests/test_e2e_database_operations.py
+++ b/tests/test_e2e_database_operations.py
@@ -4,11 +4,14 @@ E2E tests with real PostgreSQL database.
 
 Tests application code (DBHelper, messaging) against a real database.
 """
+
 import uuid
+
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
 import pytest
+
 
 pytestmark = pytest.mark.e2e
 

--- a/tests/test_e2e_webhook_flow.py
+++ b/tests/test_e2e_webhook_flow.py
@@ -4,10 +4,13 @@ E2E tests for complete webhook flow with real database.
 
 Tests the full application flow: endpoint → handler → database → activity-API
 """
+
 import uuid
+
 from unittest.mock import patch
 
 import pytest
+
 
 pytestmark = pytest.mark.e2e
 
@@ -52,8 +55,8 @@ def mr_payload():
             "author_id": 1,
             "assignee_id": None,
             "title": "Test MR",
-            "created_at": "2025-01-01T00:00:00Z",
-            "updated_at": "2025-01-01T00:00:00Z",
+            "created_at": "2025-01-01 00:00:00 UTC",
+            "updated_at": "2025-01-01 00:00:00 UTC",
             "state": "opened",
             "merge_status": "can_be_merged",
             "detailed_merge_status": "not_open",
@@ -83,10 +86,11 @@ async def test_e2e_mr_open_creates_database_records(
     db_connection, clean_database, mr_payload, mock_activity_api, test_database_url
 ):
     """Test MR open creates GitLab instance, MR ref, and message ref."""
-    from db import DBHelper, DatabaseLifecycleHandler
     from config import DefaultConfig
-    from webhook.merge_request import merge_request
+    from db import DatabaseLifecycleHandler
+    from db import DBHelper
     from gitlab_model import MergeRequestPayload
+    from webhook.merge_request import merge_request
 
     config = DefaultConfig()
     config.DATABASE_URL = test_database_url
@@ -103,7 +107,6 @@ async def test_e2e_mr_open_creates_database_records(
         patch("db.database", db_lifecycle),
         patch("webhook.merge_request.render") as mock_render,
     ):
-
         mock_render.return_value = {"type": "AdaptiveCard"}
 
         conv_token = str(uuid.uuid4())
@@ -137,10 +140,11 @@ async def test_e2e_mr_merge_creates_deletion_record(
     db_connection, clean_database, mr_payload, mock_activity_api, test_database_url
 ):
     """Test MR merge creates deletion record in msg_to_delete."""
-    from db import DBHelper, DatabaseLifecycleHandler
     from config import DefaultConfig
-    from webhook.merge_request import merge_request
+    from db import DatabaseLifecycleHandler
+    from db import DBHelper
     from gitlab_model import MergeRequestPayload
+    from webhook.merge_request import merge_request
 
     config = DefaultConfig()
     config.DATABASE_URL = test_database_url
@@ -158,7 +162,6 @@ async def test_e2e_mr_merge_creates_deletion_record(
         patch("webhook.merge_request.render") as mock_render,
         patch("webhook.merge_request.periodic_cleanup"),
     ):
-
         mock_render.return_value = {"type": "AdaptiveCard"}
 
         conv_token = str(uuid.uuid4())
@@ -208,10 +211,11 @@ async def test_e2e_multiple_conversation_tokens(
     db_connection, clean_database, mr_payload, mock_activity_api, test_database_url
 ):
     """Test MR with multiple conversation tokens creates multiple message refs."""
-    from db import DBHelper, DatabaseLifecycleHandler
     from config import DefaultConfig
-    from webhook.merge_request import merge_request
+    from db import DatabaseLifecycleHandler
+    from db import DBHelper
     from gitlab_model import MergeRequestPayload
+    from webhook.merge_request import merge_request
 
     config = DefaultConfig()
     config.DATABASE_URL = test_database_url
@@ -228,7 +232,6 @@ async def test_e2e_multiple_conversation_tokens(
         patch("db.database", db_lifecycle),
         patch("webhook.merge_request.render") as mock_render,
     ):
-
         mock_render.return_value = {"type": "AdaptiveCard"}
 
         conv_tokens = [str(uuid.uuid4()), str(uuid.uuid4()), str(uuid.uuid4())]
@@ -256,10 +259,11 @@ async def test_e2e_approval_updates_extra_state(
     db_connection, clean_database, mr_payload, mock_activity_api, test_database_url
 ):
     """Test approval webhook updates merge_request_extra_state."""
-    from db import DBHelper, DatabaseLifecycleHandler
     from config import DefaultConfig
-    from webhook.merge_request import merge_request
+    from db import DatabaseLifecycleHandler
+    from db import DBHelper
     from gitlab_model import MergeRequestPayload
+    from webhook.merge_request import merge_request
 
     config = DefaultConfig()
     config.DATABASE_URL = test_database_url
@@ -276,7 +280,6 @@ async def test_e2e_approval_updates_extra_state(
         patch("db.database", db_lifecycle),
         patch("webhook.merge_request.render") as mock_render,
     ):
-
         mock_render.return_value = {"type": "AdaptiveCard"}
 
         conv_token = str(uuid.uuid4())
@@ -322,10 +325,11 @@ async def test_e2e_draft_to_ready_deletes_old_messages(
     db_connection, clean_database, mr_payload, mock_activity_api, test_database_url
 ):
     """Test draft-to-ready transition deletes old messages."""
-    from db import DBHelper, DatabaseLifecycleHandler
     from config import DefaultConfig
-    from webhook.merge_request import merge_request
+    from db import DatabaseLifecycleHandler
+    from db import DBHelper
     from gitlab_model import MergeRequestPayload
+    from webhook.merge_request import merge_request
 
     config = DefaultConfig()
     config.DATABASE_URL = test_database_url
@@ -343,7 +347,6 @@ async def test_e2e_draft_to_ready_deletes_old_messages(
         patch("webhook.merge_request.render") as mock_render,
         patch("webhook.merge_request.periodic_cleanup"),
     ):
-
         mock_render.return_value = {"type": "AdaptiveCard"}
 
         conv_token = str(uuid.uuid4())
@@ -397,10 +400,11 @@ async def test_e2e_idempotent_webhook_processing(
     db_connection, clean_database, mr_payload, mock_activity_api, test_database_url
 ):
     """Test processing same webhook multiple times is idempotent."""
-    from db import DBHelper, DatabaseLifecycleHandler
     from config import DefaultConfig
-    from webhook.merge_request import merge_request
+    from db import DatabaseLifecycleHandler
+    from db import DBHelper
     from gitlab_model import MergeRequestPayload
+    from webhook.merge_request import merge_request
 
     config = DefaultConfig()
     config.DATABASE_URL = test_database_url
@@ -417,7 +421,6 @@ async def test_e2e_idempotent_webhook_processing(
         patch("db.database", db_lifecycle),
         patch("webhook.merge_request.render") as mock_render,
     ):
-
         mock_render.return_value = {"type": "AdaptiveCard"}
 
         conv_token = str(uuid.uuid4())

--- a/tests/test_mr_state_transitions.py
+++ b/tests/test_mr_state_transitions.py
@@ -8,7 +8,9 @@ Tests various MR lifecycle events:
 - pipeline updates
 - approval resets on new commits
 """
+
 import uuid
+
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 from unittest.mock import patch
@@ -51,17 +53,19 @@ async def test_mr_state_open_creates_message(base_mr_payload, mock_database):
     connection = mock_database.connection
     connection.fetchrow.return_value = {"merge_request_message_ref_id": 1}
 
+    sample_mri = make_mock_mri(base_mr_payload)
+
     with (
         patch("webhook.merge_request.database", mock_database),
         patch("webhook.messaging.database", mock_database),
-        patch("webhook.merge_request.dbh.get_merge_request_ref_infos") as mock_dbh,
+        patch("webhook.merge_request.dbh.get_or_create_merge_request_ref_id", return_value=1),
+        patch("webhook.merge_request.dbh.update_merge_request_ref_payload", return_value=sample_mri),
+        patch("webhook.merge_request.dbh.get_merge_request_ref_infos", return_value=sample_mri),
         patch("webhook.merge_request.render") as mock_render,
         patch("webhook.merge_request.get_or_create_message_refs") as mock_get_or_create,
         patch("webhook.merge_request.get_all_message_refs") as mock_get_all,
         patch("httpx.AsyncClient") as mock_client_class,
     ):
-
-        mock_dbh.return_value = make_mock_mri(base_mr_payload)
         mock_render.return_value = {"type": "AdaptiveCard"}
         mock_get_or_create.return_value = {str(conv_token): msg_ref}
         mock_get_all.return_value = [msg_ref]
@@ -104,17 +108,19 @@ async def test_mr_state_draft_renders_collapsed(base_mr_payload, mock_database):
     connection = mock_database.connection
     connection.fetchrow.return_value = {"merge_request_message_ref_id": 1}
 
+    sample_mri = make_mock_mri(base_mr_payload)
+
     with (
         patch("webhook.merge_request.database", mock_database),
         patch("webhook.messaging.database", mock_database),
-        patch("webhook.merge_request.dbh.get_merge_request_ref_infos") as mock_dbh,
+        patch("webhook.merge_request.dbh.get_or_create_merge_request_ref_id", return_value=1),
+        patch("webhook.merge_request.dbh.update_merge_request_ref_payload", return_value=sample_mri),
+        patch("webhook.merge_request.dbh.get_merge_request_ref_infos", return_value=sample_mri),
         patch("webhook.merge_request.render") as mock_render,
         patch("webhook.merge_request.get_or_create_message_refs") as mock_get_or_create,
         patch("webhook.merge_request.get_all_message_refs") as mock_get_all,
         patch("httpx.AsyncClient") as mock_client_class,
     ):
-
-        mock_dbh.return_value = make_mock_mri(base_mr_payload)
         mock_render.return_value = {"type": "AdaptiveCard"}
         mock_get_or_create.return_value = {str(conv_token): msg_ref}
         mock_get_all.return_value = [msg_ref]
@@ -151,16 +157,18 @@ async def test_mr_state_merged_renders_collapsed(base_mr_payload, mock_database)
         {"merge_request_message_ref_id": 1, "conversation_token": uuid.uuid4(), "message_id": uuid.uuid4()}
     ]
 
+    sample_mri = make_mock_mri(base_mr_payload)
+
     with (
         patch("webhook.merge_request.database", mock_database),
         patch("webhook.messaging.database", mock_database),
-        patch("webhook.merge_request.dbh.get_merge_request_ref_infos") as mock_dbh,
+        patch("webhook.merge_request.dbh.get_or_create_merge_request_ref_id", return_value=1),
+        patch("webhook.merge_request.dbh.update_merge_request_ref_payload", return_value=sample_mri),
+        patch("webhook.merge_request.dbh.get_merge_request_ref_infos", return_value=sample_mri),
         patch("webhook.merge_request.render") as mock_render,
         patch("webhook.merge_request.periodic_cleanup"),
         patch("httpx.AsyncClient") as mock_client_class,
     ):
-
-        mock_dbh.return_value = make_mock_mri(base_mr_payload)
         mock_render.return_value = {"type": "AdaptiveCard"}
 
         mock_client = AsyncMock()
@@ -196,17 +204,18 @@ async def test_mr_state_closed_triggers_deletion(base_mr_payload, mock_database)
         {"merge_request_message_ref_id": 1, "conversation_token": uuid.uuid4(), "message_id": message_id}
     ]
 
+    sample_mri = make_mock_mri(base_mr_payload)
+
     with (
         patch("webhook.merge_request.database", mock_database),
         patch("webhook.messaging.database", mock_database),
-        patch("webhook.merge_request.dbh.get_merge_request_ref_infos") as mock_dbh,
+        patch("webhook.merge_request.dbh.get_or_create_merge_request_ref_id", return_value=1),
+        patch("webhook.merge_request.dbh.update_merge_request_ref_payload", return_value=sample_mri),
+        patch("webhook.merge_request.dbh.get_merge_request_ref_infos", return_value=sample_mri),
         patch("webhook.merge_request.render"),
         patch("webhook.merge_request.periodic_cleanup") as mock_cleanup,
         patch("httpx.AsyncClient") as mock_client_class,
     ):
-
-        mock_dbh.return_value = make_mock_mri(base_mr_payload)
-
         mock_client = AsyncMock()
         mock_response = MagicMock()
         mock_response.status_code = 200
@@ -248,17 +257,19 @@ async def test_mr_state_approved_updates_approvers(base_mr_payload, mock_databas
         "merge_request_extra_state": {"approvers": {"1": {"id": 1, "status": "approved"}}}
     }
 
+    sample_mri = make_mock_mri(base_mr_payload)
+
     with (
         patch("webhook.merge_request.database", mock_database),
         patch("webhook.messaging.database", mock_database),
-        patch("webhook.merge_request.dbh.get_merge_request_ref_infos") as mock_dbh,
+        patch("webhook.merge_request.dbh.get_or_create_merge_request_ref_id", return_value=1),
+        patch("webhook.merge_request.dbh.update_merge_request_ref_payload", return_value=sample_mri),
+        patch("webhook.merge_request.dbh.get_merge_request_ref_infos", return_value=sample_mri),
         patch("webhook.merge_request.render"),
         patch("webhook.merge_request.get_or_create_message_refs") as mock_get_or_create,
         patch("webhook.merge_request.get_all_message_refs") as mock_get_all,
         patch("httpx.AsyncClient") as mock_client_class,
     ):
-
-        mock_dbh.return_value = make_mock_mri(base_mr_payload)
         mock_get_or_create.return_value = {str(conv_token): msg_ref}
         mock_get_all.return_value = [msg_ref]
 
@@ -301,17 +312,19 @@ async def test_mr_state_unapproved_updates_approvers(base_mr_payload, mock_datab
         "merge_request_extra_state": {"approvers": {"1": {"id": 1, "status": "unapproved"}}}
     }
 
+    sample_mri = make_mock_mri(base_mr_payload)
+
     with (
         patch("webhook.merge_request.database", mock_database),
         patch("webhook.messaging.database", mock_database),
-        patch("webhook.merge_request.dbh.get_merge_request_ref_infos") as mock_dbh,
+        patch("webhook.merge_request.dbh.get_or_create_merge_request_ref_id", return_value=1),
+        patch("webhook.merge_request.dbh.update_merge_request_ref_payload", return_value=sample_mri),
+        patch("webhook.merge_request.dbh.get_merge_request_ref_infos", return_value=sample_mri),
         patch("webhook.merge_request.render"),
         patch("webhook.merge_request.get_or_create_message_refs") as mock_get_or_create,
         patch("webhook.merge_request.get_all_message_refs") as mock_get_all,
         patch("httpx.AsyncClient") as mock_client_class,
     ):
-
-        mock_dbh.return_value = make_mock_mri(base_mr_payload)
         mock_get_or_create.return_value = {str(conv_token): msg_ref}
         mock_get_all.return_value = [msg_ref]
 
@@ -353,17 +366,19 @@ async def test_mr_update_with_new_commits_resets_approvals(base_mr_payload, mock
     connection = mock_database.connection
     connection.fetchrow.return_value = {"merge_request_extra_state": {"approvers": {}}}
 
+    sample_mri = make_mock_mri(base_mr_payload)
+
     with (
         patch("webhook.merge_request.database", mock_database),
         patch("webhook.messaging.database", mock_database),
-        patch("webhook.merge_request.dbh.get_merge_request_ref_infos") as mock_dbh,
+        patch("webhook.merge_request.dbh.get_or_create_merge_request_ref_id", return_value=1),
+        patch("webhook.merge_request.dbh.update_merge_request_ref_payload", return_value=sample_mri),
+        patch("webhook.merge_request.dbh.get_merge_request_ref_infos", return_value=sample_mri),
         patch("webhook.merge_request.render"),
         patch("webhook.merge_request.get_or_create_message_refs") as mock_get_or_create,
         patch("webhook.merge_request.get_all_message_refs") as mock_get_all,
         patch("httpx.AsyncClient") as mock_client_class,
     ):
-
-        mock_dbh.return_value = make_mock_mri(base_mr_payload)
         mock_get_or_create.return_value = {str(conv_token): msg_ref}
         mock_get_all.return_value = [msg_ref]
 
@@ -417,18 +432,20 @@ async def test_mr_draft_to_ready_deletes_old_messages(base_mr_payload, mock_data
     ]
     connection.fetchrow.return_value = {"merge_request_extra_state": {}}
 
+    sample_mri = make_mock_mri(base_mr_payload)
+
     with (
         patch("webhook.merge_request.database", mock_database),
         patch("webhook.messaging.database", mock_database),
-        patch("webhook.merge_request.dbh.get_merge_request_ref_infos") as mock_dbh,
+        patch("webhook.merge_request.dbh.get_or_create_merge_request_ref_id", return_value=1),
+        patch("webhook.merge_request.dbh.update_merge_request_ref_payload", return_value=sample_mri),
+        patch("webhook.merge_request.dbh.get_merge_request_ref_infos", return_value=sample_mri),
         patch("webhook.merge_request.render"),
         patch("webhook.merge_request.get_or_create_message_refs") as mock_get_or_create,
         patch("webhook.merge_request.get_all_message_refs") as mock_get_all,
         patch("webhook.merge_request.periodic_cleanup") as mock_cleanup,
         patch("httpx.AsyncClient") as mock_client_class,
     ):
-
-        mock_dbh.return_value = make_mock_mri(base_mr_payload)
         mock_get_or_create.return_value = {str(conv_token): msg_ref}
         mock_get_all.return_value = [msg_ref]
 
@@ -475,17 +492,19 @@ async def test_mr_reopen_creates_message(base_mr_payload, mock_database):
     connection = mock_database.connection
     connection.fetchrow.return_value = {"merge_request_message_ref_id": 1}
 
+    sample_mri = make_mock_mri(base_mr_payload)
+
     with (
         patch("webhook.merge_request.database", mock_database),
         patch("webhook.messaging.database", mock_database),
-        patch("webhook.merge_request.dbh.get_merge_request_ref_infos") as mock_dbh,
+        patch("webhook.merge_request.dbh.get_or_create_merge_request_ref_id", return_value=1),
+        patch("webhook.merge_request.dbh.update_merge_request_ref_payload", return_value=sample_mri),
+        patch("webhook.merge_request.dbh.get_merge_request_ref_infos", return_value=sample_mri),
         patch("webhook.merge_request.render") as mock_render,
         patch("webhook.merge_request.get_or_create_message_refs") as mock_get_or_create,
         patch("webhook.merge_request.get_all_message_refs") as mock_get_all,
         patch("httpx.AsyncClient") as mock_client_class,
     ):
-
-        mock_dbh.return_value = make_mock_mri(base_mr_payload)
         mock_render.return_value = {"type": "AdaptiveCard"}
         mock_get_or_create.return_value = {str(conv_token): msg_ref}
         mock_get_all.return_value = [msg_ref]
@@ -525,17 +544,19 @@ async def test_mr_update_existing_message_uses_patch(base_mr_payload, mock_datab
         message_id=existing_message_id,
     )
 
+    sample_mri = make_mock_mri(base_mr_payload)
+
     with (
         patch("webhook.merge_request.database", mock_database),
         patch("webhook.messaging.database", mock_database),
-        patch("webhook.merge_request.dbh.get_merge_request_ref_infos") as mock_dbh,
+        patch("webhook.merge_request.dbh.get_or_create_merge_request_ref_id", return_value=1),
+        patch("webhook.merge_request.dbh.update_merge_request_ref_payload", return_value=sample_mri),
+        patch("webhook.merge_request.dbh.get_merge_request_ref_infos", return_value=sample_mri),
         patch("webhook.merge_request.render") as mock_render,
         patch("webhook.merge_request.get_or_create_message_refs") as mock_get_or_create,
         patch("webhook.merge_request.get_all_message_refs") as mock_get_all,
         patch("httpx.AsyncClient") as mock_client_class,
     ):
-
-        mock_dbh.return_value = make_mock_mri(base_mr_payload)
         mock_render.return_value = {"type": "AdaptiveCard"}
         mock_get_or_create.return_value = {str(conv_token): msg_ref}
         mock_get_all.return_value = [msg_ref]

--- a/tests/test_participant_filtering.py
+++ b/tests/test_participant_filtering.py
@@ -8,7 +8,9 @@ Tests that messages are only created/updated when:
 - Assignees/reviewers are in the filter
 - MR opener is in the filter
 """
+
 import uuid
+
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 from unittest.mock import patch
@@ -58,17 +60,19 @@ async def test_no_filter_creates_message(mr_with_participants, mock_database):
     connection = mock_database.connection
     connection.fetchrow.return_value = {"merge_request_message_ref_id": 1}
 
+    sample_mri = make_mock_mri(mr_with_participants)
+
     with (
         patch("webhook.merge_request.database", mock_database),
         patch("webhook.messaging.database", mock_database),
-        patch("webhook.merge_request.dbh.get_merge_request_ref_infos") as mock_dbh,
+        patch("webhook.merge_request.dbh.get_or_create_merge_request_ref_id", return_value=1),
+        patch("webhook.merge_request.dbh.update_merge_request_ref_payload", return_value=sample_mri),
+        patch("webhook.merge_request.dbh.get_merge_request_ref_infos", return_value=sample_mri),
         patch("webhook.merge_request.render") as mock_render,
         patch("webhook.merge_request.get_or_create_message_refs") as mock_get_or_create,
         patch("webhook.merge_request.get_all_message_refs") as mock_get_all,
         patch("httpx.AsyncClient") as mock_client_class,
     ):
-
-        mock_dbh.return_value = make_mock_mri(mr_with_participants)
         mock_render.return_value = {"type": "AdaptiveCard"}
         mock_get_or_create.return_value = {str(conv_token): msg_ref}
         mock_get_all.return_value = [msg_ref]
@@ -107,17 +111,19 @@ async def test_opener_in_filter_creates_message(mr_with_participants, mock_datab
     connection = mock_database.connection
     connection.fetchrow.return_value = {"merge_request_message_ref_id": 1}
 
+    sample_mri = make_mock_mri(mr_with_participants)
+
     with (
         patch("webhook.merge_request.database", mock_database),
         patch("webhook.messaging.database", mock_database),
-        patch("webhook.merge_request.dbh.get_merge_request_ref_infos") as mock_dbh,
+        patch("webhook.merge_request.dbh.get_or_create_merge_request_ref_id", return_value=1),
+        patch("webhook.merge_request.dbh.update_merge_request_ref_payload", return_value=sample_mri),
+        patch("webhook.merge_request.dbh.get_merge_request_ref_infos", return_value=sample_mri),
         patch("webhook.merge_request.render") as mock_render,
         patch("webhook.merge_request.get_or_create_message_refs") as mock_get_or_create,
         patch("webhook.merge_request.get_all_message_refs") as mock_get_all,
         patch("httpx.AsyncClient") as mock_client_class,
     ):
-
-        mock_dbh.return_value = make_mock_mri(mr_with_participants)
         mock_render.return_value = {"type": "AdaptiveCard"}
         mock_get_or_create.return_value = {str(conv_token): msg_ref}
         mock_get_all.return_value = [msg_ref]
@@ -154,17 +160,19 @@ async def test_assignee_in_filter_creates_message(mr_with_participants, mock_dat
     connection = mock_database.connection
     connection.fetchrow.return_value = {"merge_request_message_ref_id": 1}
 
+    sample_mri = make_mock_mri(mr_with_participants)
+
     with (
         patch("webhook.merge_request.database", mock_database),
         patch("webhook.messaging.database", mock_database),
-        patch("webhook.merge_request.dbh.get_merge_request_ref_infos") as mock_dbh,
+        patch("webhook.merge_request.dbh.get_or_create_merge_request_ref_id", return_value=1),
+        patch("webhook.merge_request.dbh.update_merge_request_ref_payload", return_value=sample_mri),
+        patch("webhook.merge_request.dbh.get_merge_request_ref_infos", return_value=sample_mri),
         patch("webhook.merge_request.render") as mock_render,
         patch("webhook.merge_request.get_or_create_message_refs") as mock_get_or_create,
         patch("webhook.merge_request.get_all_message_refs") as mock_get_all,
         patch("httpx.AsyncClient") as mock_client_class,
     ):
-
-        mock_dbh.return_value = make_mock_mri(mr_with_participants)
         mock_render.return_value = {"type": "AdaptiveCard"}
         mock_get_or_create.return_value = {str(conv_token): msg_ref}
         mock_get_all.return_value = [msg_ref]
@@ -201,17 +209,19 @@ async def test_reviewer_in_filter_creates_message(mr_with_participants, mock_dat
     connection = mock_database.connection
     connection.fetchrow.return_value = {"merge_request_message_ref_id": 1}
 
+    sample_mri = make_mock_mri(mr_with_participants)
+
     with (
         patch("webhook.merge_request.database", mock_database),
         patch("webhook.messaging.database", mock_database),
-        patch("webhook.merge_request.dbh.get_merge_request_ref_infos") as mock_dbh,
+        patch("webhook.merge_request.dbh.get_or_create_merge_request_ref_id", return_value=1),
+        patch("webhook.merge_request.dbh.update_merge_request_ref_payload", return_value=sample_mri),
+        patch("webhook.merge_request.dbh.get_merge_request_ref_infos", return_value=sample_mri),
         patch("webhook.merge_request.render") as mock_render,
         patch("webhook.merge_request.get_or_create_message_refs") as mock_get_or_create,
         patch("webhook.merge_request.get_all_message_refs") as mock_get_all,
         patch("httpx.AsyncClient") as mock_client_class,
     ):
-
-        mock_dbh.return_value = make_mock_mri(mr_with_participants)
         mock_render.return_value = {"type": "AdaptiveCard"}
         mock_get_or_create.return_value = {str(conv_token): msg_ref}
         mock_get_all.return_value = [msg_ref]
@@ -249,17 +259,19 @@ async def test_no_participant_match_uses_update_only(mr_with_participants, mock_
     connection = mock_database.connection
     connection.fetchrow.return_value = {"merge_request_message_ref_id": 1}
 
+    sample_mri = make_mock_mri(mr_with_participants)
+
     with (
         patch("webhook.merge_request.database", mock_database),
         patch("webhook.messaging.database", mock_database),
-        patch("webhook.merge_request.dbh.get_merge_request_ref_infos") as mock_dbh,
+        patch("webhook.merge_request.dbh.get_or_create_merge_request_ref_id", return_value=1),
+        patch("webhook.merge_request.dbh.update_merge_request_ref_payload", return_value=sample_mri),
+        patch("webhook.merge_request.dbh.get_merge_request_ref_infos", return_value=sample_mri),
         patch("webhook.merge_request.render") as mock_render,
         patch("webhook.merge_request.get_or_create_message_refs") as mock_get_or_create,
         patch("webhook.merge_request.get_all_message_refs") as mock_get_all,
         patch("httpx.AsyncClient") as mock_client_class,
     ):
-
-        mock_dbh.return_value = make_mock_mri(mr_with_participants)
         mock_render.return_value = {"type": "AdaptiveCard"}
         mock_get_or_create.return_value = {str(conv_token): msg_ref}
         mock_get_all.return_value = [msg_ref]
@@ -298,17 +310,19 @@ async def test_multiple_participants_in_filter(mr_with_participants, mock_databa
     connection = mock_database.connection
     connection.fetchrow.return_value = {"merge_request_message_ref_id": 1}
 
+    sample_mri = make_mock_mri(mr_with_participants)
+
     with (
         patch("webhook.merge_request.database", mock_database),
         patch("webhook.messaging.database", mock_database),
-        patch("webhook.merge_request.dbh.get_merge_request_ref_infos") as mock_dbh,
+        patch("webhook.merge_request.dbh.get_or_create_merge_request_ref_id", return_value=1),
+        patch("webhook.merge_request.dbh.update_merge_request_ref_payload", return_value=sample_mri),
+        patch("webhook.merge_request.dbh.get_merge_request_ref_infos", return_value=sample_mri),
         patch("webhook.merge_request.render") as mock_render,
         patch("webhook.merge_request.get_or_create_message_refs") as mock_get_or_create,
         patch("webhook.merge_request.get_all_message_refs") as mock_get_all,
         patch("httpx.AsyncClient") as mock_client_class,
     ):
-
-        mock_dbh.return_value = make_mock_mri(mr_with_participants)
         mock_render.return_value = {"type": "AdaptiveCard"}
         mock_get_or_create.return_value = {str(conv_token): msg_ref}
         mock_get_all.return_value = [msg_ref]
@@ -342,6 +356,7 @@ def test_filter_validation_in_endpoint(test_database_url):
     database._config = config
 
     from fastapi.testclient import TestClient
+
     from app import app
 
     with TestClient(app) as client:
@@ -360,12 +375,12 @@ def test_filter_validation_in_endpoint(test_database_url):
                     "id": 123,
                     "iid": 1,
                     "title": "Test MR",
-                    "created_at": "2025-01-01T00:00:00Z",
+                    "created_at": "2025-01-01 00:00:00 UTC",
                     "draft": False,
                     "state": "opened",
                     "url": "https://gitlab.example.com/test/project/-/merge_requests/1",
                     "action": "open",
-                    "updated_at": "2025-01-01T00:00:00Z",
+                    "updated_at": "2025-01-01 00:00:00 UTC",
                     "detailed_merge_status": "mergeable",
                     "head_pipeline_id": None,
                     "work_in_progress": False,
@@ -394,6 +409,7 @@ def test_invalid_filter_format_returns_400(test_database_url):
     database._config = config
 
     from fastapi.testclient import TestClient
+
     from app import app
 
     with TestClient(app) as client:
@@ -412,12 +428,12 @@ def test_invalid_filter_format_returns_400(test_database_url):
                     "id": 123,
                     "iid": 1,
                     "title": "Test MR",
-                    "created_at": "2025-01-01T00:00:00Z",
+                    "created_at": "2025-01-01 00:00:00 UTC",
                     "draft": False,
                     "state": "opened",
                     "url": "https://gitlab.example.com/test/project/-/merge_requests/1",
                     "action": "open",
-                    "updated_at": "2025-01-01T00:00:00Z",
+                    "updated_at": "2025-01-01 00:00:00 UTC",
                     "detailed_merge_status": "mergeable",
                     "head_pipeline_id": None,
                     "work_in_progress": False,
@@ -453,17 +469,19 @@ async def test_draft_mr_with_non_participant_uses_update_only(mr_with_participan
     connection = mock_database.connection
     connection.fetchrow.return_value = {"merge_request_message_ref_id": 1}
 
+    sample_mri = make_mock_mri(mr_with_participants)
+
     with (
         patch("webhook.merge_request.database", mock_database),
         patch("webhook.messaging.database", mock_database),
-        patch("webhook.merge_request.dbh.get_merge_request_ref_infos") as mock_dbh,
+        patch("webhook.merge_request.dbh.get_or_create_merge_request_ref_id", return_value=1),
+        patch("webhook.merge_request.dbh.update_merge_request_ref_payload", return_value=sample_mri),
+        patch("webhook.merge_request.dbh.get_merge_request_ref_infos", return_value=sample_mri),
         patch("webhook.merge_request.render") as mock_render,
         patch("webhook.merge_request.get_or_create_message_refs") as mock_get_or_create,
         patch("webhook.merge_request.get_all_message_refs") as mock_get_all,
         patch("httpx.AsyncClient") as mock_client_class,
     ):
-
-        mock_dbh.return_value = make_mock_mri(mr_with_participants)
         mock_render.return_value = {"type": "AdaptiveCard"}
         mock_get_or_create.return_value = {str(conv_token): msg_ref}
         mock_get_all.return_value = [msg_ref]

--- a/tests/test_periodic_cleanup.py
+++ b/tests/test_periodic_cleanup.py
@@ -7,9 +7,11 @@ Critical bug scenarios tested:
 2. No retry mechanism for failed deletions
 3. Network timeouts and rate limiting
 """
+
 import asyncio
 import datetime
 import uuid
+
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 from unittest.mock import patch
@@ -37,8 +39,8 @@ async def test_activity_api_failure_leaves_record_in_database(mock_database, fre
 
     Location: periodic_cleanup.py:57-58
     """
-    from periodic_cleanup import _cleanup_task
     from config import DefaultConfig
+    from periodic_cleanup import _cleanup_task
 
     connection = mock_database.connection
 
@@ -68,7 +70,7 @@ async def test_activity_api_failure_leaves_record_in_database(mock_database, fre
         task = _cleanup_task(config, mock_database)
         try:
             await asyncio.wait_for(task, timeout=0.1)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             pass
 
     assert client.request.call_count == 1
@@ -86,8 +88,8 @@ async def test_activity_api_network_timeout(mock_database, fresh_signal):
 
     Location: periodic_cleanup.py:43-58
     """
-    from periodic_cleanup import _cleanup_task
     from config import DefaultConfig
+    from periodic_cleanup import _cleanup_task
 
     connection = mock_database.connection
 
@@ -101,7 +103,7 @@ async def test_activity_api_network_timeout(mock_database, fresh_signal):
     connection.fetchval.return_value = None
 
     client = AsyncMock()
-    client.request.side_effect = asyncio.TimeoutError("Connection timeout")
+    client.request.side_effect = TimeoutError("Connection timeout")
 
     config = DefaultConfig()
 
@@ -112,7 +114,7 @@ async def test_activity_api_network_timeout(mock_database, fresh_signal):
         task = _cleanup_task(config, mock_database)
         try:
             await asyncio.wait_for(task, timeout=0.1)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             pass
 
     assert client.request.call_count == 1
@@ -130,8 +132,8 @@ async def test_activity_api_rate_limiting(mock_database, fresh_signal):
 
     Location: periodic_cleanup.py:50-51
     """
-    from periodic_cleanup import _cleanup_task
     from config import DefaultConfig
+    from periodic_cleanup import _cleanup_task
 
     connection = mock_database.connection
 
@@ -161,7 +163,7 @@ async def test_activity_api_rate_limiting(mock_database, fresh_signal):
         task = _cleanup_task(config, mock_database)
         try:
             await asyncio.wait_for(task, timeout=0.1)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             pass
 
     assert client.request.call_count == 1
@@ -178,8 +180,8 @@ async def test_successful_deletion_with_410_gone(mock_database, fresh_signal):
 
     Location: periodic_cleanup.py:50
     """
-    from periodic_cleanup import _cleanup_task
     from config import DefaultConfig
+    from periodic_cleanup import _cleanup_task
 
     connection = mock_database.connection
 
@@ -206,7 +208,7 @@ async def test_successful_deletion_with_410_gone(mock_database, fresh_signal):
         task = _cleanup_task(config, mock_database)
         try:
             await asyncio.wait_for(task, timeout=0.1)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             pass
 
     assert client.request.call_count == 1
@@ -226,8 +228,8 @@ async def test_successful_deletion_with_200_ok(mock_database, fresh_signal):
 
     Location: periodic_cleanup.py:50
     """
-    from periodic_cleanup import _cleanup_task
     from config import DefaultConfig
+    from periodic_cleanup import _cleanup_task
 
     connection = mock_database.connection
 
@@ -254,7 +256,7 @@ async def test_successful_deletion_with_200_ok(mock_database, fresh_signal):
         task = _cleanup_task(config, mock_database)
         try:
             await asyncio.wait_for(task, timeout=0.1)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             pass
 
     assert client.request.call_count == 1
@@ -274,8 +276,8 @@ async def test_multiple_records_first_fails_second_succeeds(mock_database, fresh
 
     Location: periodic_cleanup.py:40-58
     """
-    from periodic_cleanup import _cleanup_task
     from config import DefaultConfig
+    from periodic_cleanup import _cleanup_task
 
     connection = mock_database.connection
 
@@ -310,7 +312,7 @@ async def test_multiple_records_first_fails_second_succeeds(mock_database, fresh
         task = _cleanup_task(config, mock_database)
         try:
             await asyncio.wait_for(task, timeout=0.1)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             pass
 
     assert client.request.call_count == 2
@@ -328,8 +330,8 @@ async def test_db_delete_fails_after_api_success(mock_database, fresh_signal):
 
     Location: periodic_cleanup.py:52-55
     """
-    from periodic_cleanup import _cleanup_task
     from config import DefaultConfig
+    from periodic_cleanup import _cleanup_task
 
     connection = mock_database.connection
 
@@ -357,7 +359,7 @@ async def test_db_delete_fails_after_api_success(mock_database, fresh_signal):
         task = _cleanup_task(config, mock_database)
         try:
             await asyncio.wait_for(task, timeout=0.1)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             pass
 
     assert client.request.call_count == 1
@@ -397,8 +399,8 @@ async def test_wait_time_calculation_with_future_expiry(mock_database, fresh_sig
 
     Location: periodic_cleanup.py:59-61
     """
-    from periodic_cleanup import _cleanup_task
     from config import DefaultConfig
+    from periodic_cleanup import _cleanup_task
 
     connection = mock_database.connection
 
@@ -418,7 +420,7 @@ async def test_wait_time_calculation_with_future_expiry(mock_database, fresh_sig
         task = _cleanup_task(config, mock_database)
         try:
             await asyncio.wait_for(task, timeout=0.1)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             pass
 
     assert connection.fetchval.call_count == 1

--- a/webhook/__init__.py
+++ b/webhook/__init__.py
@@ -3,4 +3,5 @@ from .emoji import emoji
 from .merge_request import merge_request
 from .pipeline import pipeline
 
+
 __all__ = ["merge_request", "pipeline", "emoji"]

--- a/webhook/merge_request.py
+++ b/webhook/merge_request.py
@@ -2,11 +2,11 @@
 import datetime
 import hashlib
 
-import asyncpg
 import fastapi_structured_logging
 import httpx
 
 import periodic_cleanup
+
 from cards.render import render
 from config import config
 from db import database
@@ -18,7 +18,18 @@ from webhook.messaging import get_or_create_message_refs
 from webhook.messaging import update_all_messages_transactional
 from webhook.messaging import update_message_with_fingerprint
 
+
 logger = fastapi_structured_logging.get_logger()
+
+
+class PartialMessageUpdateError(Exception):
+    """Raised when some but not all messages were updated successfully."""
+
+    def __init__(self, total: int, failed: int, message: str = ""):
+        self.total = total
+        self.failed = failed
+        self.succeeded = total - failed
+        super().__init__(message or f"{failed}/{total} message updates failed")
 
 
 async def merge_request(
@@ -28,14 +39,56 @@ async def merge_request(
     new_commits_revoke_approvals: bool,
 ):
     payload_fingerprint = hashlib.sha256(mr.model_dump_json().encode("utf8")).hexdigest()
-    logger.debug("payload fingerprint: %s", payload_fingerprint)
+    if mr.object_attributes.updated_at:
+        payload_updated_at = datetime.datetime.fromisoformat(
+            mr.object_attributes.updated_at.replace(" UTC", "+00:00")
+        )
+    else:
+        payload_updated_at = datetime.datetime.now(datetime.UTC)
+    logger.info(
+        "processing merge_request hook",
+        project_id=mr.object_attributes.target_project_id,
+        merge_request_iid=mr.object_attributes.iid,
+        object_kind=mr.object_kind,
+        fingerprint=payload_fingerprint,
+        updated_at=payload_updated_at.isoformat(),
+    )
 
     is_closing_action = mr.object_attributes.action in ("merge", "close") or mr.object_attributes.state in (
         "closed",
         "merged",
     )
 
-    mri = await dbh.get_merge_request_ref_infos(mr)
+    # Phase 1: Get/create MR ref ID WITHOUT updating payload
+    # This prevents payload corruption from OOO events
+    merge_request_ref_id = await dbh.get_or_create_merge_request_ref_id(mr)
+
+    # Early out-of-order check
+    # Reopen bypasses OOO: recreates messages after close, or updates existing if close arrives late
+    # Closing actions check OOO: late close must not delete a reopened MR's messages
+    is_reopen_action = mr.object_attributes.action == "reopen"
+    if not is_reopen_action:
+        async with await database.acquire() as connection:
+            row = await connection.fetchrow(
+                """SELECT MAX(last_processed_updated_at) as max_updated_at
+                   FROM merge_request_message_ref
+                   WHERE merge_request_ref_id = $1""",
+                merge_request_ref_id,
+            )
+            if row and row.get("max_updated_at") is not None:
+                if payload_updated_at < row["max_updated_at"]:
+                    logger.warning(
+                        "skipping entire out of order event",
+                        merge_request_ref_id=merge_request_ref_id,
+                        payload_updated_at=payload_updated_at.isoformat(),
+                        stored_max_updated_at=row["max_updated_at"].isoformat(),
+                    )
+                    return
+                # Same timestamp implies same fingerprint (fingerprint includes updated_at)
+                # so duplicate detection is already handled by fingerprint check later
+
+    # Phase 2: OOO check passed - now safe to update payload
+    mri = await dbh.update_merge_request_ref_payload(merge_request_ref_id, mr)
 
     need_cleanup_reschedule = False
 
@@ -44,14 +97,10 @@ async def merge_request(
         participant_found = False
         participant_found |= mri.merge_request_extra_state.opener.id in participant_ids_filter
         participant_found |= any(
-            [
-                user.id in participant_ids_filter
-                for userlist in (mri.merge_request_payload.assignees, mri.merge_request_payload.reviewers)
-                for user in userlist
-            ]
+            user.id in participant_ids_filter
+            for userlist in (mri.merge_request_payload.assignees, mri.merge_request_payload.reviewers)
+            for user in userlist
         )
-
-    connection: asyncpg.Connection
 
     if mr.object_attributes.action in ("update"):
         async with await database.acquire() as connection:
@@ -77,7 +126,6 @@ async def merge_request(
                     {},
                     mri.merge_request_ref_id,
                 )
-                print(mri.merge_request_ref_id)
                 if row is not None:
                     mri.merge_request_extra_state = row["merge_request_extra_state"]
 
@@ -99,6 +147,7 @@ async def merge_request(
                     temp_card,
                     temp_summary,
                     payload_fingerprint,
+                    payload_updated_at,
                     "draft-to-ready",
                     schedule_deletion=True,
                     deletion_delay=datetime.timedelta(seconds=0),
@@ -147,6 +196,7 @@ async def merge_request(
             card,
             summary,
             payload_fingerprint,
+            payload_updated_at,
             "close/merge",
             schedule_deletion=True,
             deletion_delay=datetime.timedelta(seconds=config.MESSAGE_DELETE_DELAY_SECONDS),
@@ -160,59 +210,95 @@ async def merge_request(
 
         all_message_refs = await get_all_message_refs(mri.merge_request_ref_id)
 
+        messages_processed = 0
+        messages_failed = 0
+
         timeout = httpx.Timeout(10.0, connect=5.0)
         async with httpx.AsyncClient(timeout=timeout) as client:
             for mrmsgref in all_message_refs:
-                if mrmsgref.last_processed_fingerprint == payload_fingerprint:
-                    logger.debug(
-                        "message ref already processed with this fingerprint - skipping",
-                        merge_request_message_ref_id=mrmsgref.merge_request_message_ref_id,
-                        fingerprint=payload_fingerprint,
-                    )
-                    continue
-
-                if mrmsgref.message_id is None:
-                    conv_token_str = str(mrmsgref.conversation_token)
-                    if conv_token_str not in conversation_tokens:
-                        logger.debug(
-                            "message ref has no message_id, conv_token not in webhook - skipping",
+                if mrmsgref.last_processed_updated_at is not None:
+                    if payload_updated_at < mrmsgref.last_processed_updated_at:
+                        logger.warning(
+                            "skipping out of order event",
                             merge_request_message_ref_id=mrmsgref.merge_request_message_ref_id,
-                            conversation_token=conv_token_str,
+                            payload_updated_at=payload_updated_at.isoformat(),
+                            stored_updated_at=mrmsgref.last_processed_updated_at.isoformat(),
+                        )
+                        continue
+                    if (
+                        payload_updated_at == mrmsgref.last_processed_updated_at
+                        and mrmsgref.last_processed_fingerprint == payload_fingerprint
+                    ):
+                        logger.debug(
+                            "message ref already processed - same timestamp and fingerprint",
+                            merge_request_message_ref_id=mrmsgref.merge_request_message_ref_id,
+                            fingerprint=payload_fingerprint,
                         )
                         continue
 
-                    mrmsgref.message_id = await create_or_update_message(
-                        client,
-                        mrmsgref,
-                        card=card,
-                        summary=summary,
-                        update_only=(
-                            (
-                                mr.object_attributes.action not in ("open", "reopen")
-                                and (mr.object_attributes.draft or mr.object_attributes.work_in_progress)
+                try:
+                    if mrmsgref.message_id is None:
+                        conv_token_str = str(mrmsgref.conversation_token)
+                        if conv_token_str not in conversation_tokens:
+                            logger.debug(
+                                "message ref has no message_id, conv_token not in webhook - skipping",
+                                merge_request_message_ref_id=mrmsgref.merge_request_message_ref_id,
+                                conversation_token=conv_token_str,
                             )
-                            or not participant_found
-                        ),
+                            continue
+
+                        mrmsgref.message_id = await create_or_update_message(
+                            client,
+                            mrmsgref,
+                            card=card,
+                            summary=summary,
+                            update_only=(
+                                (
+                                    mr.object_attributes.action not in ("open", "reopen")
+                                    and (mr.object_attributes.draft or mr.object_attributes.work_in_progress)
+                                )
+                                or not participant_found
+                            ),
+                        )
+
+                        if mrmsgref.message_id is not None:
+                            async with await database.acquire() as conn:
+                                await conn.execute(
+                                    """UPDATE merge_request_message_ref
+                                       SET message_id = $1, last_processed_fingerprint = $2,
+                                           last_processed_updated_at = $3
+                                       WHERE merge_request_message_ref_id = $4
+                                         AND (last_processed_updated_at IS NULL
+                                              OR last_processed_updated_at < $3)""",
+                                    mrmsgref.message_id,
+                                    payload_fingerprint,
+                                    payload_updated_at,
+                                    mrmsgref.merge_request_message_ref_id,
+                                )
+                    else:
+                        await update_message_with_fingerprint(
+                            client,
+                            mrmsgref,
+                            card,
+                            summary,
+                            payload_fingerprint,
+                            payload_updated_at,
+                        )
+                    messages_processed += 1
+                except Exception:
+                    messages_failed += 1
+                    logger.error(
+                        "failed to process message, continuing to next",
+                        merge_request_message_ref_id=mrmsgref.merge_request_message_ref_id,
+                        conversation_token=str(mrmsgref.conversation_token),
+                        exc_info=True,
                     )
 
-                    if mrmsgref.message_id is not None:
-                        async with await database.acquire() as conn:
-                            await conn.execute(
-                                """UPDATE merge_request_message_ref
-                                   SET message_id = $1, last_processed_fingerprint = $2
-                                   WHERE merge_request_message_ref_id = $3""",
-                                mrmsgref.message_id,
-                                payload_fingerprint,
-                                mrmsgref.merge_request_message_ref_id,
-                            )
-                else:
-                    await update_message_with_fingerprint(
-                        client,
-                        mrmsgref,
-                        card,
-                        summary,
-                        payload_fingerprint,
-                    )
+        if messages_failed > 0:
+            raise PartialMessageUpdateError(
+                total=messages_processed + messages_failed,
+                failed=messages_failed,
+            )
 
     if need_cleanup_reschedule:
         periodic_cleanup.reschedule()

--- a/webhook/merge_request.py
+++ b/webhook/merge_request.py
@@ -39,12 +39,9 @@ async def merge_request(
     new_commits_revoke_approvals: bool,
 ):
     payload_fingerprint = hashlib.sha256(mr.model_dump_json().encode("utf8")).hexdigest()
-    if mr.object_attributes.updated_at:
-        payload_updated_at = datetime.datetime.fromisoformat(
-            mr.object_attributes.updated_at.replace(" UTC", "+00:00")
-        )
-    else:
-        payload_updated_at = datetime.datetime.now(datetime.UTC)
+    payload_updated_at = datetime.datetime.fromisoformat(
+        mr.object_attributes.updated_at.replace(" UTC", "+00:00")
+    )
     logger.info(
         "processing merge_request hook",
         project_id=mr.object_attributes.target_project_id,


### PR DESCRIPTION
feat: add out-of-order webhook event protection (DB MIGRATION REQUIRED)

GitLab webhook call order worsens over time, making OOO handling critical.

- Add last_processed_updated_at column to track event timestamps
- Skip stale events where updated_at < last_processed_updated_at
- New DB methods: get_or_create_merge_request_ref_id(),
update_merge_request_ref_payload()
- Add PartialMessageUpdateError for partial update failures
- Switch from black/flake8 to ruff for linting
- Make OTEL instrumentation conditional in run.sh
