### PR TITLE
chore: bump pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,14 +2,14 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.3
+    rev: v0.15.12
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -24,7 +24,7 @@ repos:
         language_version: python3
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.17.0
+    rev: v3.21.2
     hooks:
       - id: pyupgrade
         args: [--py36-plus]
@@ -35,7 +35,7 @@ repos:
       - id: detect-secrets
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.11.2
+    rev: v1.20.2
     hooks:
       - id: mypy
         additional_dependencies:

--- a/tests/test_db_migrate_e2e.py
+++ b/tests/test_db_migrate_e2e.py
@@ -126,11 +126,11 @@ class TestMigrateE2E:
             """)
             column_names = {row["column_name"] for row in columns}
 
-            assert (
-                "last_processed_fingerprint" in column_names
-            ), "Column from migration 20250121010000 should exist"
-            assert (
-                "last_processed_updated_at" in column_names
-            ), "Column from migration 20251210000000 should exist"
+            assert "last_processed_fingerprint" in column_names, (
+                "Column from migration 20250121010000 should exist"
+            )
+            assert "last_processed_updated_at" in column_names, (
+                "Column from migration 20251210000000 should exist"
+            )
         finally:
             await conn.close()

--- a/tests/test_e2e_race_conditions.py
+++ b/tests/test_e2e_race_conditions.py
@@ -1005,9 +1005,9 @@ async def test_e2e_race_close_after_reopen_ooo(
 
     # Timestamp should still be from reopen (March), not close (February)
     final_updated_at = msg_refs_final[0]["last_processed_updated_at"]
-    assert final_updated_at == datetime.datetime(
-        2025, 3, 1, 0, 0, 0, tzinfo=datetime.UTC
-    ), f"Timestamp should be from reopen (March), not close. Got {final_updated_at}"
+    assert final_updated_at == datetime.datetime(2025, 3, 1, 0, 0, 0, tzinfo=datetime.UTC), (
+        f"Timestamp should be from reopen (March), not close. Got {final_updated_at}"
+    )
 
     # Close should have returned early (None result indicates early return)
     assert result is None, "Close should have been rejected and returned early"
@@ -1124,6 +1124,6 @@ async def test_e2e_race_update_arrives_before_open_with_older_timestamp(
     # Verify timestamp is from the newer event (Open with T1)
     final_updated_at = msg_refs[0]["last_processed_updated_at"]
     expected_ts = datetime.datetime(2025, 12, 22, 9, 7, 23, tzinfo=datetime.UTC)
-    assert (
-        final_updated_at == expected_ts
-    ), f"Timestamp should be from Open event (09:07:23). Got {final_updated_at}"
+    assert final_updated_at == expected_ts, (
+        f"Timestamp should be from Open event (09:07:23). Got {final_updated_at}"
+    )


### PR DESCRIPTION
## Summary
- ruff v0.8.3 -> v0.15.12 (cosmetic assertion-message reformat in two e2e test files applied by the new ruff-format)
- pre-commit-hooks v5.0.0 -> v6.0.0
- pyupgrade v3.17.0 -> v3.21.2 (fixes `cannot use a bytes pattern on a string-like object` under Python 3.14)
- mypy v1.11.2 -> v1.20.2

## Test plan
- [x] `pre-commit run --all-files` clean
- [x] `pytest` 230/230 (full suite incl. e2e against testcontainer)