### PR TITLE
chore: bump release workflow actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       attestations: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Define TARGETS
         run: |
           REPOS="ghcr.io/${{ github.repository }}"
@@ -51,10 +51,10 @@ jobs:
           echo COMMIT_SHA=$GITHUB_SHA  >>$GITHUB_ENV
           echo GITHUB_REPO="ghcr.io/${{ github.repository }}" >>$GITHUB_ENV
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -62,7 +62,7 @@ jobs:
 
       - name: Build and push
         id: push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true
@@ -75,7 +75,7 @@ jobs:
             GITHUB_REPO=${{ env.GITHUB_REPO }}
 
       - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v1
+        uses: actions/attest-build-provenance@v4
         with:
           subject-name: ghcr.io/${{ github.repository }}
           subject-digest: ${{ steps.push.outputs.digest }}


### PR DESCRIPTION
- actions/checkout v4 -> v6
- docker/setup-buildx-action v3 -> v4
- docker/login-action v3 -> v4
- docker/build-push-action v6 -> v7
- actions/attest-build-provenance v1 -> v4

Validated locally with `act --dryrun` on release.yml (all action refs resolve, all steps green).